### PR TITLE
Add version of NPM that matches node version for access to npx

### DIFF
--- a/stack-build-agent/h79.1-n12.22.1-jdk11/Dockerfile
+++ b/stack-build-agent/h79.1-n12.22.1-jdk11/Dockerfile
@@ -19,6 +19,7 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.12/main' >> /etc/apk/repositor
     && apk add --no-cache \
     make \
     "nodejs<13.0.0" \
+    "npm=12.22.10-r0" \
     "hugo>0.76.5" \
     openjdk11-jdk \
     maven \


### PR DESCRIPTION
Needed for some builds to properly run scripts pulled through yarn ([yarn 1.x has no npx replacement](https://github.com/yarnpkg/yarn/issues/3937)).