### PR TITLE
Add version to yarn so v of node is respected

### DIFF
--- a/stack-build-agent/h79.1-n12.22.1-jdk11/Dockerfile
+++ b/stack-build-agent/h79.1-n12.22.1-jdk11/Dockerfile
@@ -19,11 +19,11 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.12/main' >> /etc/apk/repositor
     && apk add --no-cache \
     make \
     "nodejs<13.0.0" \
-    "npm=12.22.10-r0" \
+    "npm~=12.22.10-r0" \
     "hugo>0.76.5" \
     openjdk11-jdk \
     maven \
-    yarn \
+    "yarn=1.22.4-r0" \
     curl \
     bash
 

--- a/stack-build-agent/h79.1-n12.22.1-jdk11/Dockerfile
+++ b/stack-build-agent/h79.1-n12.22.1-jdk11/Dockerfile
@@ -19,11 +19,11 @@ RUN echo 'http://dl-cdn.alpinelinux.org/alpine/v3.12/main' >> /etc/apk/repositor
     && apk add --no-cache \
     make \
     "nodejs<13.0.0" \
-    "npm~=12.22.10-r0" \
+    "npm~=12.22.12" \
     "hugo>0.76.5" \
     openjdk11-jdk \
     maven \
-    "yarn=1.22.4-r0" \
+    "yarn=1.22.10-r0" \
     curl \
     bash
 


### PR DESCRIPTION
Alpine 3.13 uses a version of yarn that includes v14 of nodejs which
conflicts with earlier explicit installed version 12. By using the v3.12
package version of yarn we should be in lockstep with version.