### PR TITLE
replace h0.99.1-n16.15.0 with h0.110.0-n18.13.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ build kubectl okd-c1 latest
 
 build hugo-node h0.62.2-n10.15.0
 build hugo-node h0.99.1-n16.15.0
-build hugo-node h0.104.3-n16.17.1
+build hugo-node h0.110.0-n18.13.0
 build hugo-node h0.76.5-n12.22.1 latest
 
 build stack-build-agent h79.1-n12.22.1-jdk11 latest

--- a/hugo-node/h0.110.0-n18.13.0/Dockerfile
+++ b/hugo-node/h0.110.0-n18.13.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update && apt-get install -y \
     git \
     --no-install-recommends
 
-RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/v16.17.1/node-v16.17.1-linux-x64.tar.xz" \
+RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/v18.13.0/node-v18.13.0-linux-x64.tar.xz" \
     && mkdir -p /usr/local/lib/nodejs \
     && tar -xJf /tmp/node.tar.xz -C /usr/local/lib/nodejs \
     && rm -f /tmp/node.tar.xz \
-    && ln -s /usr/local/lib/nodejs/node-v16.17.1-linux-x64/bin/node /usr/bin/node \
-    && ln -s /usr/local/lib/nodejs/node-v16.17.1-linux-x64/bin/npm /usr/bin/npm \
-    && ln -s /usr/local/lib/nodejs/node-v16.17.1-linux-x64/bin/npx /usr/bin/npx \
-    && npm install -g yarn@1.22.10 \
-    && ln -s /usr/local/lib/nodejs/node-v16.17.1-linux-x64/bin/yarn /usr/bin/yarn
+    && ln -s /usr/local/lib/nodejs/node-v18.13.0-linux-x64/bin/node /usr/bin/node \
+    && ln -s /usr/local/lib/nodejs/node-v18.13.0-linux-x64/bin/npm /usr/bin/npm \
+    && ln -s /usr/local/lib/nodejs/node-v18.13.0-linux-x64/bin/npx /usr/bin/npx \
+    && npm install -g yarn@1.22.19 \
+    && ln -s /usr/local/lib/nodejs/node-v18.13.0-linux-x64/bin/yarn /usr/bin/yarn
 
 RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v0.104.3/hugo_0.104.3_linux-amd64.deb" \
     && dpkg -i /tmp/hugo.deb \

--- a/hugo-node/h0.110.0-n18.13.0/Dockerfile
+++ b/hugo-node/h0.110.0-n18.13.0/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/v18.13.0/node-v18.13.0-
     && npm install -g yarn@1.22.19 \
     && ln -s /usr/local/lib/nodejs/node-v18.13.0-linux-x64/bin/yarn /usr/bin/yarn
 
-RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v0.104.3/hugo_0.104.3_linux-amd64.deb" \
+RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_0.110.0_linux-amd64.deb" \
     && dpkg -i /tmp/hugo.deb \
     && rm -f /tmp/hugo.deb
 


### PR DESCRIPTION
We never had the time to start using h0.99.1-n16.15.0 but I would like to start working on this today or next week.

Instead of creating a new version, I decided to replace the last one I created.

Any concerns with this approach?