### PR TITLE
Missing hugo version in alpine, upgrade to r4

### DIFF
--- a/stack-build-agent/h111.3-n18.17-jdk11/Dockerfile
+++ b/stack-build-agent/h111.3-n18.17-jdk11/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
     make \
     "nodejs=18.17.1-r0" \
     "npm=9.6.6-r0" \
-    "hugo=0.111.3-r3" \
+    "hugo=0.111.3-r4" \
     "yarn=1.22.19-r0" \
     openjdk11-jdk \
     maven \


### PR DESCRIPTION
Upgrade hugo package to latest r4, r3 is not anymore present in alpine mirrors.