### PR TITLE
Create base Java image for shared API runtimes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,6 @@ build drupal-node d9.5.10-n18.17.1 latest
 build stack-build-agent h79.1-n12.22.1-jdk11 latest
 build stack-build-agent h111.3-n18.17-jdk11
 
-build java-base-image j11-openjdk latest
+build java-api-base j11-openjdk latest
 
 build containertools alpine-latest latest

--- a/build.sh
+++ b/build.sh
@@ -33,4 +33,6 @@ build drupal-node d9.5.10-n18.17.1 latest
 build stack-build-agent h79.1-n12.22.1-jdk11 latest
 build stack-build-agent h111.3-n18.17-jdk11
 
+build java-base-image j11-openjdk latest
+
 build containertools alpine-latest latest

--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,9 @@ build drupal-node d9.5.10-n18.17.1 latest
 
 build stack-build-agent h79.1-n12.22.1-jdk11 latest
 build stack-build-agent h111.3-n18.17-jdk11
+build stack-build-agent h111.3-n18.17-jdk17
 
 build java-api-base j11-openjdk latest
+build java-api-base j17-openjdk
 
 build containertools alpine-latest latest

--- a/java-api-base/j11-openjdk/Dockerfile
+++ b/java-api-base/j11-openjdk/Dockerfile
@@ -10,13 +10,7 @@ USER root
 # Required to patch for CVEs as base image doesn't appear to run patches
 RUN microdnf upgrade -y
 
-# We make four distinct layers so if there are application changes the library layers can be re-used
-COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
-COPY --chown=1001 target/quarkus-app/*.jar /deployments/
-COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
-COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
-
 EXPOSE 8080
-USER 1001
+
 ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/java-api-base/j11-openjdk/Dockerfile
+++ b/java-api-base/j11-openjdk/Dockerfile
@@ -6,6 +6,7 @@
 FROM registry.access.redhat.com/ubi9/openjdk-11:1.16-1
 ENV LANGUAGE='en_US:en'
 
+USER root
 # Required to patch for CVEs as base image doesn't appear to run patches
 RUN microdnf upgrade -y
 

--- a/java-api-base/j11-openjdk/Dockerfile
+++ b/java-api-base/j11-openjdk/Dockerfile
@@ -1,0 +1,21 @@
+####
+# This Dockerfile is used in order to build a container that runs the Quarkus application in JVM mode
+#
+# Based on the image provided by Quarkus in quickstarts with some modifications
+####
+FROM registry.access.redhat.com/ubi9/openjdk-11:1.16-1
+ENV LANGUAGE='en_US:en'
+
+# Required to patch for CVEs as base image doesn't appear to run patches
+RUN microdnf upgrade -y
+
+# We make four distinct layers so if there are application changes the library layers can be re-used
+COPY --chown=1001 target/quarkus-app/lib/ /deployments/lib/
+COPY --chown=1001 target/quarkus-app/*.jar /deployments/
+COPY --chown=1001 target/quarkus-app/app/ /deployments/app/
+COPY --chown=1001 target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 1001
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"

--- a/java-api-base/j17-openjdk/Dockerfile
+++ b/java-api-base/j17-openjdk/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Based on the image provided by Quarkus in quickstarts with some modifications
 ####
-FROM registry.access.redhat.com/ubi9/openjdk-11:1.16-3
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.16-3
 ENV LANGUAGE='en_US:en'
 
 USER root

--- a/stack-build-agent/h111.3-n18.17-jdk11/Dockerfile
+++ b/stack-build-agent/h111.3-n18.17-jdk11/Dockerfile
@@ -16,9 +16,9 @@ FROM eclipsecbi/alpine:3.18
 
 RUN apk add --no-cache \
     make \
-    "nodejs=18.17.1-r0" \
+    "nodejs=18.18.2-r0" \
     "npm=9.6.6-r0" \
-    "hugo=0.111.3-r4" \
+    "hugo=0.111.3-r5" \
     "yarn=1.22.19-r0" \
     openjdk11-jdk \
     maven \

--- a/stack-build-agent/h111.3-n18.17-jdk17/Dockerfile
+++ b/stack-build-agent/h111.3-n18.17-jdk17/Dockerfile
@@ -1,0 +1,32 @@
+
+#*******************************************************************************
+# Copyright (c) 2021 Eclipse Foundation and others.
+# This program and the accompanying materials are made available
+# under the terms of the Eclipse Public License 2.0
+# which is available at http://www.eclipse.org/legal/epl-v20.html
+# SPDX-License-Identifier: EPL-2.0
+#*******************************************************************************
+
+##
+# Installs required build tools that will be used in the compilation process
+# of fullstack development environments. This includes set and tested minimum
+# versions of node.js, Hugo, and Java.
+##
+FROM eclipsecbi/alpine:3.18
+
+RUN apk add --no-cache \
+    make \
+    "nodejs=18.18.2-r0" \
+    "npm=9.6.6-r0" \
+    "hugo=0.111.3-r5" \
+    "yarn=1.22.19-r0" \
+    openjdk17-jdk \
+    maven \
+    curl \
+    bash
+
+ENV JAVA_HOME="/usr/lib/jvm/java-17-openjdk"
+ENV PATH=$PATH:/usr/lib/jvm/java-17-openjdk/bin
+
+USER 10001:0
+


### PR DESCRIPTION
Previously, we've had to do updates in every repo to update our Java APIs to fix versions exposed by vulnerabilities or bugs. This image centralizes the image and makes it easier to keep up to date with package updates, or switch Java versions in the future.

The idea here is initially this will be Java 11, but in the future, we can add the Java 17 base image and eventually switch it to latest to reduce the amount of changes and deployments we need to manually tweak/configure. This will help us close vulnerabilities like the current glibc CVE more proactively.