### PR TITLE
Add golang to installed packages, as required by hugo module.

### DIFF
--- a/hugo-node/Dockerfile
+++ b/hugo-node/Dockerfile
@@ -7,6 +7,7 @@ ARG NODE_VERSION=v18.13.0
 
 RUN apt-get update && apt-get install -y \
     build-essential \
+    golang \
     ca-certificates \
     curl \
     git \


### PR DESCRIPTION
Hi @oliviergoulet5 @chrisguindon,

As suggested in https://gitlab.eclipse.org/eclipse/plato/www/-/issues/22 this is Fix MR to add go exec in docker image, in order to build https://gitlab.eclipse.org/eclipse/plato/www/-/merge_requests/114

Tested it on one of my amd64 machines, works well. :-)