### PR TITLE
add hugo-v0.124.1-node-js-v20.11.1 image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,9 +47,9 @@ pipeline {
 
         stage('hugo-node') {
           steps {
-            buildImage('hugo-node', 'h0.76.5-n12.22.1', 'hugo-node', ['HUGO_VERSION':'0.76.5', 'HUGO_FILENAME':'hugo_0.76.5_Linux-64bit.deb','NODE_VERSION': 'v12.22.1'], true)
+            buildImage('hugo-node', 'h0.76.5-n12.22.1', 'hugo-node', ['HUGO_VERSION':'0.76.5', 'HUGO_FILENAME':'hugo_0.76.5_Linux-64bit.deb','NODE_VERSION': 'v12.22.1'])
             buildImage('hugo-node', 'h0.99.1-n16.15.0', 'hugo-node', ['HUGO_VERSION':'0.99.1', 'HUGO_FILENAME':'hugo_0.99.1_Linux-64bit.deb','NODE_VERSION': 'v16.15.0'])
-            buildImage('hugo-node', 'h0.110.0-n18.19.1', 'hugo-node', ['HUGO_VERSION':'0.110.0', 'NODE_VERSION': 'v18.19.1'])
+            buildImage('hugo-node', 'h0.110.0-n18.19.1', 'hugo-node', ['HUGO_VERSION':'0.110.0', 'NODE_VERSION': 'v18.19.1'], true)
             buildImage('hugo-node', 'h0.120.4-n18.19.1', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.120.4', 'NODE_VERSION': 'v18.19.1'])
             buildImage('hugo-node', 'h0.124.1-n20.11.1', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.124.1', 'NODE_VERSION': 'v20.11.1'])
           }
@@ -57,8 +57,8 @@ pipeline {
 
         stage('drupal-node') {
           steps {
-            buildImage('drupal-node', 'd9.5.10-n18.18.2', 'drupal-node', ['DRUPAL_VERSION':'9.5.10', 'NODE_VERSION': 'v18.18.2'], true)
-            buildImage('drupal-node', 'd10.2.2-n18.19.1', 'drupal-node', ['DRUPAL_VERSION':'10.2.2', 'NODE_VERSION': 'v18.19.1'])
+            buildImage('drupal-node', 'd9.5.10-n18.18.2', 'drupal-node', ['DRUPAL_VERSION':'9.5.10', 'NODE_VERSION': 'v18.18.2'])
+            buildImage('drupal-node', 'd10.2.2-n18.19.1', 'drupal-node', ['DRUPAL_VERSION':'10.2.2', 'NODE_VERSION': 'v18.19.1'], true)
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ pipeline {
             buildImage('hugo-node', 'h0.99.1-n16.15.0', 'hugo-node', ['HUGO_VERSION':'0.99.1', 'HUGO_FILENAME':'hugo_0.99.1_Linux-64bit.deb','NODE_VERSION': 'v16.15.0'])
             buildImage('hugo-node', 'h0.110.0-n18.19.1', 'hugo-node', ['HUGO_VERSION':'0.110.0', 'NODE_VERSION': 'v18.19.1'])
             buildImage('hugo-node', 'h0.120.4-n18.19.1', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.120.4', 'NODE_VERSION': 'v18.19.1'])
+            buildImage('hugo-node', 'h0.124.1-n20.11.1', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.124.1', 'NODE_VERSION': 'v20.11.1'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -25,13 +25,14 @@ build_arg planet-venus debian-10-slim "" latest
 
 build kubectl okd-c1 latest
 
-build_arg hugo-node h0.76.5-n12.22.1 "--build-arg HUGO_VERSION=0.76.5 --build-arg HUGO_FILENAME=hugo_0.76.5_Linux-64bit.deb --build-arg NODE_VERSION=v12.22.1" latest
+build_arg hugo-node h0.76.5-n12.22.1 "--build-arg HUGO_VERSION=0.76.5 --build-arg HUGO_FILENAME=hugo_0.76.5_Linux-64bit.deb --build-arg NODE_VERSION=v12.22.1"
 build_arg hugo-node h0.99.1-n16.15.0 "--build-arg HUGO_VERSION=0.99.1 --build-arg HUGO_FILENAME=hugo_0.99.1_Linux-64bit.deb --build-arg NODE_VERSION=v16.15.0"
-build_arg hugo-node h0.110.0-n18.13.0 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.13.0"
+build_arg hugo-node h0.110.0-n18.13.0 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.13.0" latest
 build_arg hugo-node h0.120.4-n18.18.2 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.120.4 --build-arg NODE_VERSION=v18.18.2"
+build_arg hugo-node h0.124.1-n18.18.2 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
 
-build_arg drupal-node d9.5.10-n18.18.2 "--build-arg DRUPAL_VERSION=9.5.10 --build-arg NODE_VERSION=v18.18.2" latest
-build_arg drupal-node d10.2.2-n18.19.0 "--build-arg DRUPAL_VERSION=10.2.2 --build-arg NODE_VERSION=v18.19.0"
+build_arg drupal-node d9.5.10-n18.18.2 "--build-arg DRUPAL_VERSION=9.5.10 --build-arg NODE_VERSION=v18.18.2"
+build_arg drupal-node d10.2.2-n18.19.0 "--build-arg DRUPAL_VERSION=10.2.2 --build-arg NODE_VERSION=v18.19.0" latest
 
 build stack-build-agent h79.1-n12.22.1-jdk11 latest
 build_arg stack-build-agent h111.3-n18.18-jdk17 "--build-arg JDK_VERSION=17"


### PR DESCRIPTION
I am also setting HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.13.0 to be the latest image for now since this is what we official support at this time.