### PR TITLE
Stack build agent based on alpine 3.19

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,6 +103,7 @@ pipeline {
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk11', 'stack-build-agent')
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
+            buildImage('stack-build-agent', 'a3.19-h120-n20-jdk17', 'stack-build-agent', ['ALPINE_VERSION':'3.19', 'JDK_VERSION':'17', 'NODE_VERSION':'20.12.1-r0', 'NPM_VERSION':'10.2.5-r0', 'HUGO_VERSION':'0.120.4-r3', 'YARN_VERSION':'1.22.19-r0'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,7 @@ build_arg stack-build-agent h111.3-n18.18-jdk17 "--build-arg JDK_VERSION=17"
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11
 build_arg stack-build-agent h111.3-n18.17-jdk17 "--build-arg JDK_VERSION=17"
+build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.19 --build-arg JDK_VERSION=17 --build-arg NODE_VERSION=20.12.1-r0 --build-arg NPM_VERSION=10.2.5-r0 --build-arg HUGO_VERSION=0.120.4-r3 --build-arg YARN_VERSION=1.22.19-r0"
 
 ## Used for native builds
 build_arg native-build-agent m23-n18.20.2 latest


### PR DESCRIPTION
Based image alpine version is 3.19
To keep compatibility with previous version 3.19, I propose this new tag convention: `a3.19-h120-n20-jdk17`
Adding alpine, and keep only major versions for other packages: nodejs, hugo, jdk. 