### PR TITLE
update drupal hugo and node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,8 @@ pipeline {
             }
           }
           steps {
-            buildImage('drupal-node', 'd10.3.13-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.3.13', 'NODE_VERSION': 'v22.14.0'], true)
-            buildImage('drupal-node', 'd11.1.3-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.1.3', 'NODE_VERSION': 'v22.14.0'])
+            buildImage('drupal-node', 'd10.3.12-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.3.12', 'NODE_VERSION': 'v22.14.0'], true)
+            buildImage('drupal-node', 'd11.1.2-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.1.2', 'NODE_VERSION': 'v22.14.0'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,7 @@ pipeline {
             buildImage('hugo-node', 'h0.110.0-n18.19.1', 'hugo-node', ['HUGO_VERSION':'0.110.0', 'NODE_VERSION': 'v18.19.1'], true)
             buildImage('hugo-node', 'h0.120.4-n18.19.1', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.120.4', 'NODE_VERSION': 'v18.19.1'])
             buildImage('hugo-node', 'h0.124.1-n20.11.1', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.124.1', 'NODE_VERSION': 'v20.11.1'])
+            buildImage('hugo-node', 'h0.144.2-n22.14.0', 'hugo-node', ['DEBIAN_VERSION':'12-slim', 'HUGO_VERSION':'0.144.2', 'NODE_VERSION': 'v22.14.0'])
           }
         }
 
@@ -85,8 +86,8 @@ pipeline {
             }
           }
           steps {
-            buildImage('drupal-node', 'd9.5.10-n18.18.2', 'drupal-node', ['DRUPAL_VERSION':'9.5.10', 'NODE_VERSION': 'v18.18.2'])
-            buildImage('drupal-node', 'd10.2.2-n18.19.1', 'drupal-node', ['DRUPAL_VERSION':'10.2.2', 'NODE_VERSION': 'v18.19.1'], true)
+            buildImage('drupal-node', 'd10.3.13-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.3.13', 'NODE_VERSION': 'v22.14.0'], true)
+            buildImage('drupal-node', 'd11.1.3-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.1.3', 'NODE_VERSION': 'v22.14.0'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,8 @@ pipeline {
             }
           }
           steps {
-            buildImage('drupal-node', 'd10.3.12-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.3.12', 'NODE_VERSION': 'v22.14.0'], true)
-            buildImage('drupal-node', 'd11.1.2-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.1.2', 'NODE_VERSION': 'v22.14.0'])
+            buildImage('drupal-node', 'd10.3.13-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.3.13', 'NODE_VERSION': 'v22.14.0'], true)
+            buildImage('drupal-node', 'd11.1.3-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.1.3', 'NODE_VERSION': 'v22.14.0'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -29,9 +29,12 @@ build_arg hugo-node h0.99.1-n16.15.0 "--build-arg HUGO_VERSION=0.99.1 --build-ar
 build_arg hugo-node h0.110.0-n18.19.1 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.19.1" latest
 build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.120.4 --build-arg NODE_VERSION=v18.19.1"
 build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
+build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
 
-build_arg drupal-node d9.5.10-n18.18.2 "--build-arg DRUPAL_VERSION=9.5.10 --build-arg NODE_VERSION=v18.18.2"
-build_arg drupal-node d10.2.2-n18.19.0 "--build-arg DRUPAL_VERSION=10.2.2 --build-arg NODE_VERSION=v18.19.0" latest
+build_arg drupal-node d10.2.2-n18.19.0 "--build-arg DRUPAL_VERSION=10.2.2 --build-arg NODE_VERSION=v18.19.0"
+build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
+build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
+
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 latest

--- a/build.sh
+++ b/build.sh
@@ -31,10 +31,8 @@ build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --buil
 build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
 build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
 
-build_arg drupal-node d10.2.2-n18.19.0 "--build-arg DRUPAL_VERSION=10.2.2 --build-arg NODE_VERSION=v18.19.0"
 build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
 build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
-
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 latest

--- a/build.sh
+++ b/build.sh
@@ -31,8 +31,8 @@ build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --buil
 build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
 build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
 
-build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
-build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
+build_arg drupal-node d10.3.12-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.12 --build-arg NODE_VERSION=v22.14.0" latest
+build_arg drupal-node d11.1.2-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.2 --build-arg NODE_VERSION=v22.14.0"
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 latest

--- a/build.sh
+++ b/build.sh
@@ -25,14 +25,14 @@ build_arg planet-venus debian-10-slim "" latest
 
 build kubectl okd-c1 latest
 
-build_arg hugo-node h0.99.1-n16.15.0 "--build-arg HUGO_VERSION=0.99.1 --build-arg HUGO_FILENAME=hugo_0.99.1_Linux-64bit.deb --build-arg NODE_VERSION=v16.15.0"
-build_arg hugo-node h0.110.0-n18.19.1 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.19.1" latest
-build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.120.4 --build-arg NODE_VERSION=v18.19.1"
-build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
-build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
+build_arg hugo-node h0.99.1-n16.15.0 "--build-arg HUGO_VERSION=0.99.1 --build-arg HUGO_FILENAME=hugo_0.99.1_Linux-64bit.deb --build-arg NODE_VERSION=v16.15.0 --build-arg YARN_VERSION=v1.22.19"
+build_arg hugo-node h0.110.0-n18.19.1 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.19.1 --build-arg YARN_VERSION=v1.22.19" latest
+build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.120.4 --build-arg NODE_VERSION=v18.19.1 --build-arg YARN_VERSION=v1.22.19"
+build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1 --build-arg YARN_VERSION=v1.22.19"
+build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0 --build-arg YARN_VERSION=v1.22.22"
 
-build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
-build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
+build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0 --build-arg YARN_VERSION=v1.22.22" latest
+build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0 --build-arg YARN_VERSION=v1.22.22"
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 latest

--- a/build.sh
+++ b/build.sh
@@ -31,8 +31,8 @@ build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --buil
 build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
 build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
 
-build_arg drupal-node d10.3.12-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.12 --build-arg NODE_VERSION=v22.14.0" latest
-build_arg drupal-node d11.1.2-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.2 --build-arg NODE_VERSION=v22.14.0"
+build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
+build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 latest

--- a/build.sh
+++ b/build.sh
@@ -25,14 +25,14 @@ build_arg planet-venus debian-10-slim "" latest
 
 build kubectl okd-c1 latest
 
-build_arg hugo-node h0.99.1-n16.15.0 "--build-arg HUGO_VERSION=0.99.1 --build-arg HUGO_FILENAME=hugo_0.99.1_Linux-64bit.deb --build-arg NODE_VERSION=v16.15.0 --build-arg YARN_VERSION=v1.22.19"
-build_arg hugo-node h0.110.0-n18.19.1 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.19.1 --build-arg YARN_VERSION=v1.22.19" latest
-build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.120.4 --build-arg NODE_VERSION=v18.19.1 --build-arg YARN_VERSION=v1.22.19"
-build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1 --build-arg YARN_VERSION=v1.22.19"
-build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0 --build-arg YARN_VERSION=v1.22.22"
+build_arg hugo-node h0.99.1-n16.15.0 "--build-arg HUGO_VERSION=0.99.1 --build-arg HUGO_FILENAME=hugo_0.99.1_Linux-64bit.deb --build-arg NODE_VERSION=v16.15.0"
+build_arg hugo-node h0.110.0-n18.19.1 "--build-arg HUGO_VERSION=0.110.0 --build-arg NODE_VERSION=v18.19.1" latest
+build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.120.4 --build-arg NODE_VERSION=v18.19.1"
+build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
+build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
 
-build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0 --build-arg YARN_VERSION=v1.22.22" latest
-build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0 --build-arg YARN_VERSION=v1.22.22"
+build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
+build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 latest

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
   && npm install -g npm@${NPM_VERSION} \
-  && npm install -g yarn@1.22.19 \
+  && npm install -g yarn \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 # Configure directories and files

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -5,7 +5,6 @@ FROM drupal:${DRUPAL_VERSION}-apache
 # Set default build-time variables
 ARG NODE_VERSION=v22.14.0
 ARG NPM_VERSION=11.1.0
-ARG YARN_VERSION=1.22.22
 
 # Install necessary packages and PHP extensions
 RUN apt update && apt install -y libldap2-dev git mariadb-client vim rsync \
@@ -23,7 +22,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
   && npm install -g npm@${NPM_VERSION} \
-  && npm install -g yarn@${YARN_VERSION} \
+  && npm install -g yarn@1.22.19 \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 # Configure directories and files

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -1,10 +1,10 @@
 # Base Image
-ARG DRUPAL_VERSION=9.5.10
+ARG DRUPAL_VERSION=10.3.13
 FROM drupal:${DRUPAL_VERSION}-apache
 
 # Set default build-time variables
-ARG NODE_VERSION=v18.17.1
-ARG NPM_VERSION=10.2.3
+ARG NODE_VERSION=v22.14.0
+ARG NPM_VERSION=11.1.0
 
 # Install necessary packages and PHP extensions
 RUN apt update && apt install -y libldap2-dev git mariadb-client vim rsync \

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -5,6 +5,7 @@ FROM drupal:${DRUPAL_VERSION}-apache
 # Set default build-time variables
 ARG NODE_VERSION=v22.14.0
 ARG NPM_VERSION=11.1.0
+ARG YARN_VERSION=1.22.22
 
 # Install necessary packages and PHP extensions
 RUN apt update && apt install -y libldap2-dev git mariadb-client vim rsync \
@@ -22,7 +23,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
   && npm install -g npm@${NPM_VERSION} \
-  && npm install -g yarn@1.22.19 \
+  && npm install -g yarn@${YARN_VERSION} \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 # Configure directories and files

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
   && npm install -g npm@${NPM_VERSION} \
-  && npm install -g yarn \
+  && npm install -g yarn@1.22.19 \
   && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 # Configure directories and files

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-ARG DRUPAL_VERSION=10.3.13
+ARG DRUPAL_VERSION=10.3.12
 FROM drupal:${DRUPAL_VERSION}-apache
 
 # Set default build-time variables

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-ARG DRUPAL_VERSION=10.3.12
+ARG DRUPAL_VERSION=10.3.13
 FROM drupal:${DRUPAL_VERSION}-apache
 
 # Set default build-time variables

--- a/hugo-node/Dockerfile
+++ b/hugo-node/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/node /usr/bin/node \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
-    && npm install -g yarn \
+    && npm install -g yarn@1.22.19 \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_FILENAME}" \

--- a/hugo-node/Dockerfile
+++ b/hugo-node/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:${DEBIAN_VERSION} AS builder
 ARG HUGO_VERSION=0.110.0
 ARG HUGO_FILENAME=hugo_extended_${HUGO_VERSION}_linux-amd64.deb
 ARG NODE_VERSION=v18.19.1
+ARG YARN_VERSION=1.22.19
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -20,7 +21,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/node /usr/bin/node \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
-    && npm install -g yarn@1.22.19 \
+    && npm install -g yarn@${YARN_VERSION} \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_FILENAME}" \

--- a/hugo-node/Dockerfile
+++ b/hugo-node/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/node /usr/bin/node \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
-    && npm install -g yarn@1.22.19 \
+    && npm install -g yarn \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_FILENAME}" \

--- a/hugo-node/Dockerfile
+++ b/hugo-node/Dockerfile
@@ -4,7 +4,6 @@ FROM debian:${DEBIAN_VERSION} AS builder
 ARG HUGO_VERSION=0.110.0
 ARG HUGO_FILENAME=hugo_extended_${HUGO_VERSION}_linux-amd64.deb
 ARG NODE_VERSION=v18.19.1
-ARG YARN_VERSION=1.22.19
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -21,7 +20,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/node /usr/bin/node \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
-    && npm install -g yarn@${YARN_VERSION} \
+    && npm install -g yarn@1.22.19 \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
 
 RUN curl -L -o /tmp/hugo.deb "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_FILENAME}" \


### PR DESCRIPTION
Creating a new Hugo image with the latest Hugo 0.144.2 and Node.js 22 LTS .

For Drupal, I am dropping the old Drupal 9 image and updating the latest Drupal 10 image to 10.3.13. The latest Drupal image will be upgraded today to Node.js LTS 22 to begin testing for any breaking changes.

Additionally, I am introducing a new Drupal 11.1 image to start migrating our sites to D11.

//cc @ericpoirier @autumnfound @oliviergoulet5 