### PR TITLE
feat: Add new Java base image for v21, update base image to fix vuln's

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -116,8 +116,9 @@ pipeline {
             }
           }
           steps {
-            buildImage('java-api-base', 'j11-openjdk', 'java-api-base', ['JDK_VERSION':'11:1.17'], true)
-            buildImage('java-api-base', 'j17-openjdk', 'java-api-base', ['JDK_VERSION':'17:1.17'])
+            buildImage('java-api-base', 'j11-openjdk', 'java-api-base', ['JDK_VERSION':'11:1.17'])
+            buildImage('java-api-base', 'j17-openjdk', 'java-api-base', ['JDK_VERSION':'17:1.22-1.1752621170'], true)
+            buildImage('java-api-base', 'j21-openjdk', 'java-api-base', ['JDK_VERSION':'21:1.22-1.1752676422'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -44,8 +44,8 @@ build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.2
 build_arg native-build-agent m23-n18.20.2 "" latest
 build_arg native-build-agent m23-n22 "--build-arg NODE_VERSION=v22.17.0"
 
-build_arg java-api-base j11-openjdk "--build-arg JDK_VERSION=11:1.17" latest
-build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170"
+build_arg java-api-base j11-openjdk "--build-arg JDK_VERSION=11:1.17"
+build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170" latest
 build_arg java-api-base j21-openjdk "--build-arg JDK_VERSION=21:1.22-1.1752676422"
 
 build_arg containertools alpine-latest "" latest

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,7 @@ build_arg native-build-agent m23-n18.20.2 "" latest
 build_arg native-build-agent m23-n22 "--build-arg NODE_VERSION=v22.17.0"
 
 build_arg java-api-base j11-openjdk "--build-arg JDK_VERSION=11:1.17" latest
-build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.17"
+build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170"
+build_arg java-api-base j21-openjdk "--build-arg JDK_VERSION=21:1.22-1.1752676422"
 
 build_arg containertools alpine-latest "" latest


### PR DESCRIPTION
Updated to latest versions for versions we care about, as well as switched to java 17 as the default for now. We're planning on switching to Java 21 in the near future, but we aren't quite there yet.