### PR TITLE
feat: Update native-build-agent for modern

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,8 +131,7 @@ pipeline {
             }
           }
           steps {
-            buildImage('native-build-agent', 'm23-n18.20.2', 'native-build-agent', [:], true)
-            buildImage('native-build-agent', 'm23-n22', 'native-build-agent', ['NODE_VERSION':'v22.17.0'])
+            buildImage('native-build-agent', 'jdk21-n22', 'native-build-agent', ['NODE_VERSION':'v22.17.0'], true)
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,7 @@ build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.1
 build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.3.0-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
 
 ## Used for native builds
-build_arg native-build-agent m23-n18.20.2 "" latest
-build_arg native-build-agent m23-n22 "--build-arg NODE_VERSION=v22.17.0"
+build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest
 
 build_arg java-api-base j11-openjdk "--build-arg JDK_VERSION=11:1.17"
 build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170" latest

--- a/native-build-agent/Dockerfile
+++ b/native-build-agent/Dockerfile
@@ -13,18 +13,16 @@
 # compilation for Quarkus.
 ##
 
-ARG MANDREL_VERSION=23.0
-FROM registry.access.redhat.com/quarkus/mandrel-23-rhel8:${MANDREL_VERSION}
+ARG JAVA_VERSION=21
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-${JAVA_VERSION}
 
-ARG NODE_VERSION=v18.20.2
-ARG NPM_VERSION=9.6.6
-ARG YARN_VERSION=1.22.19
+ARG NODE_VERSION=v22.14.0
 ARG MVN_VERSION=3.9.11
 
 USER root
 
 ## Required as RHEL UBI doesn't come with xz-utils or make ootb
-RUN dnf install -y xz make
+RUN microdnf install -y xz make
 
 ## Add node/yarn as it's used as part of the Java build process to build JSON schemas from API specs
 RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz" \
@@ -34,7 +32,7 @@ RUN curl -L -o /tmp/node.tar.xz "https://nodejs.org/dist/${NODE_VERSION}/node-${
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/node /usr/bin/node \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npm /usr/bin/npm \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/npx /usr/bin/npx \
-    && npm install -g yarn@${YARN_VERSION} \
+    && npm install -g yarn \
     && ln -s /usr/local/lib/nodejs/node-${NODE_VERSION}-linux-x64/bin/yarn /usr/bin/yarn
     
 ## Add maven, as RHEL version is too old to use quarkus extensions (need 3.6+, RHEL provides 3.5.4)


### PR DESCRIPTION
This update was based on the first stage of the multiphase build as defined in the Quarkus documentation, see https://quarkus.io/version/3.20/guides/building-native-image#multistage-docker.

With this, the old images would become deprecated as they have a different image base and wouldn't be compatible with the new format.