### PR TITLE
Update Java image to use JRE base, fix broken SWD build agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,8 +117,9 @@ pipeline {
           }
           steps {
             buildImage('java-api-base', 'j11-openjdk', 'java-api-base', ['JDK_VERSION':'11:1.17'])
-            buildImage('java-api-base', 'j17-openjdk', 'java-api-base', ['JDK_VERSION':'17:1.22-1.1752621170'], true)
-            buildImage('java-api-base', 'j21-openjdk', 'java-api-base', ['JDK_VERSION':'21:1.22-1.1752676422'])
+            buildImage('java-api-base', 'j17-openjdk', 'java-api-base', ['JDK_VERSION':'17:1.22-1.1752621170'])
+            buildImage('java-api-base', 'j21-openjdk', 'java-api-base', ['JDK_VERSION':'21:1.22-1.1752676422'], true)
+            buildImage('java-api-base', 'j21-openjdk-runtime', 'java-api-base', ['JDK_VERSION':'21-runtime:1.23'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,8 +75,9 @@ pipeline {
         stage('java-api-base') {
           steps {
             buildImage('java-api-base', 'j11-openjdk', 'java-api-base', ['JDK_VERSION':'11:1.17'])
-            buildImage('java-api-base', 'j17-openjdk', 'java-api-base', ['JDK_VERSION':'17:1.22-1.1752621170'], true)
-            buildImage('java-api-base', 'j21-openjdk', 'java-api-base', ['JDK_VERSION':'21:1.22-1.1752676422'])
+            buildImage('java-api-base', 'j17-openjdk', 'java-api-base', ['JDK_VERSION':'17:1.22-1.1752621170'])
+            buildImage('java-api-base', 'j21-openjdk', 'java-api-base', ['JDK_VERSION':'21:1.22-1.1752676422'], true)
+            buildImage('java-api-base', 'j21-openjdk-runtime', 'java-api-base', ['JDK_VERSION':'21-runtime:1.23'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk11', 'stack-build-agent', [:], true)
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
             buildImage('stack-build-agent', 'a3.19-h120-n20-jdk17', 'stack-build-agent', ['ALPINE_VERSION':'3.19', 'JDK_VERSION':'17', 'NODE_VERSION':'20.15.1-r0', 'NPM_VERSION':'10.2.5-r0', 'HUGO_VERSION':'0.120.4', 'YARN_VERSION':'1.22.19-r0'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.23.0-r0', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.23.2-r0', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,8 @@ build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.2
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest
 
 build_arg java-api-base j11-openjdk "--build-arg JDK_VERSION=11:1.17"
-build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170" latest
-build_arg java-api-base j21-openjdk "--build-arg JDK_VERSION=21:1.22-1.1752676422"
+build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170" 
+build_arg java-api-base j21-openjdk "--build-arg JDK_VERSION=21:1.22-1.1752676422" latest
+build_arg java-api-base j21-openjdk-runtime "--build-arg JDK_VERSION=21-runtime:1.23"
 
 build_arg containertools alpine-latest "" latest

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --buil
 build_arg stack-build-agent h111.3-n18.17-jdk11 "" latest
 build_arg stack-build-agent h111.3-n18.17-jdk17 "--build-arg JDK_VERSION=17"
 build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.19 --build-arg JDK_VERSION=17 --build-arg NODE_VERSION=20.15.1-r0 --build-arg NPM_VERSION=10.2.5-r0 --build-arg HUGO_VERSION=0.120.4 --build-arg YARN_VERSION=1.22.19-r0"
-build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.3.0-r1 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
+build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.6.3-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
 
 ## Used for native builds
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,8 @@ build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.2
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest
 
 build_arg java-api-base j11-openjdk "--build-arg JDK_VERSION=11:1.17"
-build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170" latest
-build_arg java-api-base j21-openjdk "--build-arg JDK_VERSION=21:1.22-1.1752676422"
+build_arg java-api-base j17-openjdk "--build-arg JDK_VERSION=17:1.22-1.1752621170" 
+build_arg java-api-base j21-openjdk "--build-arg JDK_VERSION=21:1.22-1.1752676422" latest
+build_arg java-api-base j21-openjdk-runtime "--build-arg JDK_VERSION=21-runtime:1.23"
 
 build_arg containertools alpine-latest "" latest

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ build_arg drupal-node d11.2.10-n22.14.0 "--build-arg DRUPAL_VERSION=11.2.10 --bu
 build_arg stack-build-agent h111.3-n18.17-jdk11 "" latest
 build_arg stack-build-agent h111.3-n18.17-jdk17 "--build-arg JDK_VERSION=17"
 build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.19 --build-arg JDK_VERSION=17 --build-arg NODE_VERSION=20.15.1-r0 --build-arg NPM_VERSION=10.2.5-r0 --build-arg HUGO_VERSION=0.120.4 --build-arg YARN_VERSION=1.22.19-r0"
-build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.22.2-r0 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
+build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.23.2-r0 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
 
 ## Used for native builds
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest

--- a/java-api-base/Dockerfile
+++ b/java-api-base/Dockerfile
@@ -8,8 +8,8 @@ FROM registry.access.redhat.com/ubi9/openjdk-${JDK_VERSION}
 ENV LANGUAGE='en_US:en'
 
 USER root
-# Required to patch for CVEs as base image doesn't appear to run patches
-RUN microdnf upgrade -y
+# Install for debugging tools
+RUN microdnf update -y && microdnf install -y procps
 
 EXPOSE 8080
 


### PR DESCRIPTION
Changes included:

- Create new image for JRE based application runtime image
- Update image to use latest tag of RHEL image
- Fix stack-build-agent image that references no longer available packages