### PR TITLE
Add version for stack-build-agent using yarn 4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,8 @@ pipeline {
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk11', 'stack-build-agent', [:], true)
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
             buildImage('stack-build-agent', 'a3.19-h120-n20-jdk17', 'stack-build-agent', ['ALPINE_VERSION':'3.19', 'JDK_VERSION':'17', 'NODE_VERSION':'20.15.1-r0', 'NPM_VERSION':'10.2.5-r0', 'HUGO_VERSION':'0.120.4', 'YARN_VERSION':'1.22.19-r0'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.3.0-r1', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.3.0-r1', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline {
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
             buildImage('stack-build-agent', 'a3.19-h120-n20-jdk17', 'stack-build-agent', ['ALPINE_VERSION':'3.19', 'JDK_VERSION':'17', 'NODE_VERSION':'20.15.1-r0', 'NPM_VERSION':'10.2.5-r0', 'HUGO_VERSION':'0.120.4', 'YARN_VERSION':'1.22.19-r0'])
             buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.3.0-r1', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.3.0-r1', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,8 @@ pipeline {
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk11', 'stack-build-agent', [:], true)
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
             buildImage('stack-build-agent', 'a3.19-h120-n20-jdk17', 'stack-build-agent', ['ALPINE_VERSION':'3.19', 'JDK_VERSION':'17', 'NODE_VERSION':'20.15.1-r0', 'NPM_VERSION':'10.2.5-r0', 'HUGO_VERSION':'0.120.4', 'YARN_VERSION':'1.22.19-r0'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.22.0-r0', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.22.0-r0', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.3.0-r1', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.3.0-r1', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
           }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,8 +103,8 @@ pipeline {
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk11', 'stack-build-agent', [:], true)
             buildImage('stack-build-agent', 'h111.3-n18.19-jdk17', 'stack-build-agent', ['JDK_VERSION':'17'])
             buildImage('stack-build-agent', 'a3.19-h120-n20-jdk17', 'stack-build-agent', ['ALPINE_VERSION':'3.19', 'JDK_VERSION':'17', 'NODE_VERSION':'20.15.1-r0', 'NPM_VERSION':'10.2.5-r0', 'HUGO_VERSION':'0.120.4', 'YARN_VERSION':'1.22.19-r0'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
-            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.16.0-r2', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.22.0-r0', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'1.22.22-r1'])
+            buildImage('stack-build-agent', 'a3.22-h144-n22-y412-jdk21', 'stack-build-agent', ['ALPINE_VERSION':'3.22', 'JDK_VERSION':'21', 'NODE_VERSION':'22.22.0-r0', 'NPM_VERSION':'11.6.4-r0', 'HUGO_VERSION':'0.144.2', 'YARN_VERSION':'4.12.0'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,8 @@ build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --buil
 build_arg stack-build-agent h111.3-n18.17-jdk11 "" latest
 build_arg stack-build-agent h111.3-n18.17-jdk17 "--build-arg JDK_VERSION=17"
 build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.19 --build-arg JDK_VERSION=17 --build-arg NODE_VERSION=20.15.1-r0 --build-arg NPM_VERSION=10.2.5-r0 --build-arg HUGO_VERSION=0.120.4 --build-arg YARN_VERSION=1.22.19-r0"
-build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.3.0-r1 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
+build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
+build_arg stack-build-agent a3.22-h144-n22-y412-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=4.12.0"
 
 ## Used for native builds
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest

--- a/build.sh
+++ b/build.sh
@@ -40,8 +40,8 @@ build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --buil
 build_arg stack-build-agent h111.3-n18.17-jdk11 "" latest
 build_arg stack-build-agent h111.3-n18.17-jdk17 "--build-arg JDK_VERSION=17"
 build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.19 --build-arg JDK_VERSION=17 --build-arg NODE_VERSION=20.15.1-r0 --build-arg NPM_VERSION=10.2.5-r0 --build-arg HUGO_VERSION=0.120.4 --build-arg YARN_VERSION=1.22.19-r0"
-build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.22.0-r0 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
-build_arg stack-build-agent a3.22-h144-n22-y412-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.22.0-r0 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=4.12.0"
+build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.3.0-r1 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
+build_arg stack-build-agent a3.22-h144-n22-y412-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.3.0-r1 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=4.12.0"
 
 ## Used for native builds
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest

--- a/build.sh
+++ b/build.sh
@@ -40,8 +40,8 @@ build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --buil
 build_arg stack-build-agent h111.3-n18.17-jdk11 "" latest
 build_arg stack-build-agent h111.3-n18.17-jdk17 "--build-arg JDK_VERSION=17"
 build_arg stack-build-agent a3.19-h120-n20-jdk17 "--build-arg ALPINE_VERSION=3.19 --build-arg JDK_VERSION=17 --build-arg NODE_VERSION=20.15.1-r0 --build-arg NPM_VERSION=10.2.5-r0 --build-arg HUGO_VERSION=0.120.4 --build-arg YARN_VERSION=1.22.19-r0"
-build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
-build_arg stack-build-agent a3.22-h144-n22-y412-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.16.0-r2 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=4.12.0"
+build_arg stack-build-agent a3.22-h144-n22-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.22.0-r0 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=1.22.22-r1"
+build_arg stack-build-agent a3.22-h144-n22-y412-jdk21 "--build-arg ALPINE_VERSION=3.22 --build-arg JDK_VERSION=21 --build-arg NODE_VERSION=22.22.0-r0 --build-arg NPM_VERSION=11.6.4-r0 --build-arg HUGO_VERSION=0.144.2 --build-arg YARN_VERSION=4.12.0"
 
 ## Used for native builds
 build_arg native-build-agent jdk21-n22 "--build-arg NODE_VERSION=v22.17.0" latest

--- a/native-build-agent/Dockerfile
+++ b/native-build-agent/Dockerfile
@@ -17,7 +17,7 @@ ARG JAVA_VERSION=21
 FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-${JAVA_VERSION}
 
 ARG NODE_VERSION=v22.14.0
-ARG MVN_VERSION=3.9.11
+ARG MVN_VERSION=3.9.12
 
 USER root
 

--- a/stack-build-agent/Dockerfile
+++ b/stack-build-agent/Dockerfile
@@ -26,13 +26,20 @@ RUN apk add --no-cache \
     make \
     "nodejs=${NODE_VERSION}" \
     "npm=${NPM_VERSION}" \
-    "yarn=${YARN_VERSION}" \
     openjdk${JDK_VERSION}-jdk \
     maven \
     curl \
     bash \
     libc6-compat \
     libstdc++
+
+RUN if [[ "$YARN_VERSION" =~ "1.*" ]]; then \
+      apk add --no-cache "yarn=${YARN_VERSION}"; \
+    else \
+      npm install -g corepack; \
+      corepack enable; \
+      corepack prepare yarn@${YARN_VERSION} --activate; \
+    fi
 
 ENV JAVA_HOME="/usr/lib/jvm/java-${JDK_VERSION}-openjdk"
 ENV PATH=$PATH:/usr/lib/jvm/java-${JDK_VERSION}-openjdk/bin
@@ -42,4 +49,3 @@ RUN curl -L -o /tmp/hugo.tar.gz "https://github.com/gohugoio/hugo/releases/downl
     && tar -xf "/tmp/hugo.tar.gz" hugo -C /usr/bin
 
 USER 10001:0
-


### PR DESCRIPTION
This is needed to start migrating our apis to use yarn 4+.

Depending on the selected yarn version, yarn is either installed with apk or corepack.

This PR also updates:
  -  the npm version of the failing image on master
  - the maven version in the native-build-agent image as 3.9.11 is not available anymore from the download site

Question: the image info in Jenkinsfile and build.sh seem to be duplicated. Are both still relevant?