### PR TITLE
Update Drupal 10 and Drupal 11 version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,8 @@ pipeline {
 
         stage('drupal-node') {
           steps {
-            buildImage('drupal-node', 'd10.3.13-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.3.13', 'NODE_VERSION': 'v22.14.0'], true)
-            buildImage('drupal-node', 'd11.1.3-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.1.3', 'NODE_VERSION': 'v22.14.0'])
+            buildImage('drupal-node', 'd10.6.6-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'10.6.6', 'NODE_VERSION': 'v22.14.0'], true)
+            buildImage('drupal-node', 'd11.2.10-n22.14.0', 'drupal-node', ['DRUPAL_VERSION':'11.2.10', 'NODE_VERSION': 'v22.14.0'])
           }
         }
 

--- a/build.sh
+++ b/build.sh
@@ -33,8 +33,8 @@ build_arg hugo-node h0.120.4-n18.19.1 "--build-arg DEBIAN_VERSION=12-slim --buil
 build_arg hugo-node h0.124.1-n20.11.1 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.124.1 --build-arg NODE_VERSION=v20.11.1"
 build_arg hugo-node h0.144.2-n22.14.0 "--build-arg DEBIAN_VERSION=12-slim --build-arg HUGO_VERSION=0.144.2 --build-arg NODE_VERSION=v22.14.0"
 
-build_arg drupal-node d10.3.13-n22.14.0 "--build-arg DRUPAL_VERSION=10.3.13 --build-arg NODE_VERSION=v22.14.0" latest
-build_arg drupal-node d11.1.3-n22.14.0 "--build-arg DRUPAL_VERSION=11.1.3 --build-arg NODE_VERSION=v22.14.0"
+build_arg drupal-node d10.6.6-n22.14.0 "--build-arg DRUPAL_VERSION=10.6.6 --build-arg NODE_VERSION=v22.14.0" latest
+build_arg drupal-node d11.2.10-n22.14.0 "--build-arg DRUPAL_VERSION=11.2.10 --build-arg NODE_VERSION=v22.14.0"
 
 #node version in tag is wrong
 build_arg stack-build-agent h111.3-n18.17-jdk11 "" latest

--- a/drupal-node/Dockerfile
+++ b/drupal-node/Dockerfile
@@ -1,5 +1,5 @@
 # Base Image
-ARG DRUPAL_VERSION=10.3.13
+ARG DRUPAL_VERSION=10.6.6
 FROM drupal:${DRUPAL_VERSION}-apache
 
 # Set default build-time variables


### PR DESCRIPTION
Updating Drupal 10 version to the most up to date version.

Update Drupal 11 to the latest version to enable PHP 8.4 instead of 8.3.